### PR TITLE
fix broken sql queries

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,6 @@ export class NeonToolkit {
     project: ToolkitProject,
     query: string,
   ): Promise<ReturnType<NeonQueryFunction<boolean, boolean>>> {
-    return neon(project.connectionURIs[0].connection_uri)(query);
+    return neon(project.connectionURIs[0].connection_uri).query(query);
   }
 }


### PR DESCRIPTION
I’m not certain whether this minor tweak will be sufficient, but it did allow me to successfully run the `toolkit.sql` commands

#1 